### PR TITLE
platform: exynos9820: introduce protected_content module

### DIFF
--- a/platform/exynos9820/patches/protected_content/module.prop
+++ b/platform/exynos9820/patches/protected_content/module.prop
@@ -1,0 +1,4 @@
+id=protected_content
+name=protected_content
+author=Ocin4ever
+description=Enable device specific features that has been disabled by samsung

--- a/platform/exynos9820/patches/protected_content/smali/system/priv-app/Accessibility/Accessibility.apk/0001-Remove-device-specific-checks.patch
+++ b/platform/exynos9820/patches/protected_content/smali/system/priv-app/Accessibility/Accessibility.apk/0001-Remove-device-specific-checks.patch
@@ -1,0 +1,50 @@
+From 11be683957c37b3908ac00cae17bfdc503ff7505 Mon Sep 17 00:00:00 2001
+From: Ocin4ever <85343782+Ocin4ever@users.noreply.github.com>
+Date: Wed, 7 May 2025 23:20:40 +0200
+Subject: [PATCH] Remove device specific checks
+
+
+diff --git a/smali/l7/f.smali b/smali/l7/f.smali
+index 2714a8235e..38a632fb1c 100644
+--- a/smali/l7/f.smali
++++ b/smali/l7/f.smali
+@@ -19,15 +19,7 @@
+ 
+     sput-object v0, Ll7/f;->b:Ljava/util/HashSet;
+ 
+-    const-string v1, "beyond"
+-
+-    invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+-
+-    const-string v1, "d1"
+-
+-    invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+-
+-    const-string v1, "d2"
++    const-string v1, "fck"
+ 
+     invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+ 
+@@ -198,17 +190,11 @@
+ .end method
+ 
+ .method public static h()Z
+-    .locals 2
++    .locals 1
+ 
+-    const-string v0, "ro.surface_flinger.protected_contents"
+-
+-    const/4 v1, 0x0
++    const/4 v0, 0x1
+-
+-    invoke-static {v0, v1}, Landroid/os/SemSystemProperties;->getBoolean(Ljava/lang/String;Z)Z
+-
+-    move-result v0
+ 
+     return v0
+ .end method
+ 
+ .method public static i()Z
+-- 
+2.43.0
+

--- a/platform/exynos9820/patches/protected_content/smali/system/priv-app/SecSettings/SecSettings.apk/0001-Remove-device-specific-checks.patch
+++ b/platform/exynos9820/patches/protected_content/smali/system/priv-app/SecSettings/SecSettings.apk/0001-Remove-device-specific-checks.patch
@@ -1,0 +1,45 @@
+From e91d4b6774dc41fb26fd8152e4b583d7261d4780 Mon Sep 17 00:00:00 2001
+From: Ocin4ever <85343782+Ocin4ever@users.noreply.github.com>
+Date: Wed, 7 May 2025 23:22:48 +0200
+Subject: [PATCH] Remove device specific checks
+
+
+diff --git a/smali_classes4/com/samsung/android/settings/accessibility/SecAccessibilityUtils.smali b/smali_classes4/com/samsung/android/settings/accessibility/SecAccessibilityUtils.smali
+index eb9ab6deca..845d490688 100644
+--- a/smali_classes4/com/samsung/android/settings/accessibility/SecAccessibilityUtils.smali
++++ b/smali_classes4/com/samsung/android/settings/accessibility/SecAccessibilityUtils.smali
+@@ -21,15 +21,7 @@
+ 
+     sput-object v0, Lcom/samsung/android/settings/accessibility/SecAccessibilityUtils;->excludeDeviceNameSet:Ljava/util/HashSet;
+ 
+-    const-string v1, "beyond"
+-
+-    invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+-
+-    const-string v1, "d1"
+-
+-    invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+-
+-    const-string v1, "d2"
++    const-string v1, "fck"
+ 
+     invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+ 
+@@ -1485,13 +1477,7 @@
+ 
+     sget-boolean v1, Lcom/samsung/android/settings/accessibility/AccessibilityRune;->FEATURE_ACCESSIBILITY_SETTINGS_HOME_APPLIANCE_BACKUP:Z
+ 
+-    const-string/jumbo v1, "ro.surface_flinger.protected_contents"
+-
+-    const/4 v2, 0x0
+-
+-    invoke-static {v1, v2}, Landroid/os/SystemProperties;->getBoolean(Ljava/lang/String;Z)Z
+-
+-    move-result v1
++    const/4 v2, 0x1
+ 
+     const/4 v3, 0x1
+ 
+-- 
+2.43.0
+

--- a/platform/exynos9820/patches/protected_content/smali/system_ext/priv-app/SystemUI/SystemUI.apk/0001-Remove-device-specific-checks.patch
+++ b/platform/exynos9820/patches/protected_content/smali/system_ext/priv-app/SystemUI/SystemUI.apk/0001-Remove-device-specific-checks.patch
@@ -1,0 +1,43 @@
+From 7ecb4444e2352e60ae446967009f7bc8b214ad1c Mon Sep 17 00:00:00 2001
+From: Ocin4ever <85343782+Ocin4ever@users.noreply.github.com>
+Date: Wed, 7 May 2025 23:31:58 +0200
+Subject: [PATCH] Remove device specific checks
+
+
+diff --git a/smali_classes2/com/android/systemui/qs/tiles/ReduceBrightColorsTile.smali b/smali_classes2/com/android/systemui/qs/tiles/ReduceBrightColorsTile.smali
+index 3c3229fb0d..9dee0fd2fc 100644
+--- a/smali_classes2/com/android/systemui/qs/tiles/ReduceBrightColorsTile.smali
++++ b/smali_classes2/com/android/systemui/qs/tiles/ReduceBrightColorsTile.smali
+@@ -26,15 +26,7 @@
+ 
+     sput-object v0, Lcom/android/systemui/qs/tiles/ReduceBrightColorsTile;->excludeDeviceNameSet:Ljava/util/HashSet;
+ 
+-    const-string v1, "beyond"
+-
+-    invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+-
+-    const-string v1, "d1"
+-
+-    invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+-
+-    const-string v1, "d2"
++    const-string v1, "fck"
+ 
+     invoke-virtual {v0, v1}, Ljava/util/HashSet;->add(Ljava/lang/Object;)Z
+ 
+@@ -392,11 +384,7 @@
+ 
+     move-result v0
+ 
+-    const-string/jumbo v2, "ro.surface_flinger.protected_contents"
+-
+-    invoke-static {v2, v1}, Landroid/os/SystemProperties;->getBoolean(Ljava/lang/String;Z)Z
+-
+-    move-result v2
++    const/4 v2, 0x1
+ 
+     const/4 v3, 0x1
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
- Samsung introduced a check for the 10 series to disable the extra dim feature. 
- This check was added back in One UI 4 and is still present, which is why we need to patch it. 
- A12 and lower devices do not have the "ro.surface_flinger.protected_contents" property. 
- We cannot add it because it will break features, so we need to bypass it.