### PR TITLE
Enable Vulkan as the default rendering API

### DIFF
--- a/platform/exynos2100/patches/miscs/customize.sh
+++ b/platform/exynos2100/patches/miscs/customize.sh
@@ -4,6 +4,10 @@ SET_PROP "vendor" "external_storage.casefold.enabled" "1"
 SET_PROP "vendor" "external_storage.sdcardfs.enabled" "0"
 SET_PROP "vendor" "persist.sys.fuse.passthrough.enable" "true"
 
+echo "Enable Vulkan"
+SET_PROP "vendor" "ro.hwui.use_vulkan" "true"
+SET_PROP "vendor" "debug.hwui.use_hint_manager" "true"
+
 echo "Disabling encryption"
 # Encryption
 LINE=$(sed -n "/^\/dev\/block\/by-name\/userdata/=" "$WORK_DIR/vendor/etc/fstab.exynos2100")

--- a/platform/exynos9820/patches/miscs/customize.sh
+++ b/platform/exynos9820/patches/miscs/customize.sh
@@ -29,6 +29,10 @@ echo "Disabling HFR"
 SET_PROP "vendor" "ro.surface_flinger.enable_frame_rate_override" "false"
 SET_PROP "vendor" "ro.surface_flinger.use_content_detection_for_refresh_rate" "false"
 
+echo "Enable Vulkan"
+SET_PROP "vendor" "ro.hwui.use_vulkan" "true"
+SET_PROP "vendor" "debug.hwui.use_hint_manager" "true"
+
 # For some reason we are missing 2 permissions here: android.hardware.security.model.compatible and android.software.controls
 # First one is related to encryption and second one to SmartThings Device Control
 echo "Patching vendor permissions"

--- a/platform/exynos990/patches/miscs/customize.sh
+++ b/platform/exynos990/patches/miscs/customize.sh
@@ -22,6 +22,10 @@ if [[ "$MODEL" != "c1s" && "$MODEL" != "c2s" ]]; then
     SET_PROP "vendor" "ro.surface_flinger.enable_frame_rate_override" "true"
 fi
 
+echo "Enable Vulkan"
+SET_PROP "vendor" "ro.hwui.use_vulkan" "true"
+SET_PROP "vendor" "debug.hwui.use_hint_manager" "true"
+
 echo "Disabling encryption"
 # Encryption
 LINE=$(sed -n "/^\/dev\/block\/by-name\/userdata/=" "$WORK_DIR/vendor/etc/fstab.exynos990")


### PR DESCRIPTION
- This PR introduces the integration of the Vulkan API, replacing OpenGL
- Vulkan, being newer and faster, will significantly improve graphics performance and efficiency