### PR TITLE
target: c2s/z3s: patches: camera: fix camera zoom level

### DIFF
--- a/target/c2s/patches/camera/system/cameradata/camera-feature.xml
+++ b/target/c2s/patches/camera/system/cameradata/camera-feature.xml
@@ -112,12 +112,15 @@
     <!-- Multi-camera features -->
     <local name="SUPPORT_BACK_WIDE_NORMAL_DUAL_PORTRAIT" value="true"/>
     <local name="SUPPORT_BACK_TOF_PORTRAIT" value="true"/>
+    <local name="SUPPORT_BACK_SECOND_TELE_CAMERA" value="true"/>
     <local name="SUPPORT_SEAMLESS_ZOOM" value="true"/>
     <local name="SUPPORT_WIDE_LENS_CORRECTION" value="true"/>
     <local name="BACK_WIDE_CAMERA_ID" value="2"/>
-    <local name="BACK_TELE_CAMERA_ZOOM_LEVEL" value="5.0"/>
+    <local name="BACK_TELE_CAMERA_ZOOM_LEVEL" value="3.0"/>
     <local name="BACK_TELE_CAMERA_ID" value="52"/>
     <local name="DIGITAL_ZOOM_SHORTCUT_LIST" value="10.0, 20.0"/>
+    <local name="BACK_SECOND_TELE_CAMERA_ID" value="52"/>
+    <local name="BACK_SECOND_TELE_CAMERA_ZOOM_LEVEL" value="5.0"/>
 
     <!-- Front dynamic FOV features -->
     <local name="FRONT_DYNAMIC_FOV_CAMERA_ID" value="3"/>

--- a/target/z3s/patches/camera/system/cameradata/camera-feature.xml
+++ b/target/z3s/patches/camera/system/cameradata/camera-feature.xml
@@ -118,12 +118,15 @@
     <!-- Multi-camera features -->
     <local name="SUPPORT_BACK_WIDE_NORMAL_DUAL_PORTRAIT" value="true"/>
     <local name="SUPPORT_BACK_TOF_PORTRAIT" value="true"/>
+    <local name="SUPPORT_BACK_SECOND_TELE_CAMERA" value="true"/>
     <local name="SUPPORT_SEAMLESS_ZOOM" value="true"/>
     <local name="SUPPORT_WIDE_LENS_CORRECTION" value="true"/>
     <local name="BACK_WIDE_CAMERA_ID" value="2"/>
-    <local name="BACK_TELE_CAMERA_ZOOM_LEVEL" value="5.0"/>
+    <local name="BACK_TELE_CAMERA_ZOOM_LEVEL" value="3.0"/>
     <local name="BACK_TELE_CAMERA_ID" value="52"/>
     <local name="DIGITAL_ZOOM_SHORTCUT_LIST" value="10.0, 20.0"/>
+    <local name="BACK_SECOND_TELE_CAMERA_ID" value="52"/>
+    <local name="BACK_SECOND_TELE_CAMERA_ZOOM_LEVEL" value="5.0"/>
 
     <!-- Front dynamic FOV features -->
     <local name="FRONT_DYNAMIC_FOV_CAMERA_ID" value="3"/>


### PR DESCRIPTION
* Ultra devices require a special camera configuration to enable some camera shortcuts.
* It might be unstable on other devices, so Extreme does not want to add it.