### PR TITLE
Don't use one kernel tmp dir for both (exynos9820/exynos990) platforms

### DIFF
--- a/platform/exynos9820/patches/extremekrnl/customize.sh
+++ b/platform/exynos9820/patches/extremekrnl/customize.sh
@@ -17,7 +17,7 @@ SAFE_PULL_CHANGES()
     PARENT=$(pwd)
     cd "$KERNEL_TMP_DIR"
 
-    set -euo pipefail
+    set -eo pipefail
 
     git fetch origin
 
@@ -44,7 +44,8 @@ SAFE_PULL_CHANGES()
 
 REPLACE_KERNEL_BINARIES()
 {
-    mkdir -p "$KERNEL_TMP_DIR"
+    local KERNEL_TMP_DIR="$KERNEL_TMP_DIR-$TARGET_PLATFORM"
+    [ ! -d "$KERNEL_TMP_DIR" ] && mkdir -p "$KERNEL_TMP_DIR"
 
     echo "Cloning/updating ExtremeKernel"
 

--- a/platform/exynos990/patches/extremekrnl/customize.sh
+++ b/platform/exynos990/patches/extremekrnl/customize.sh
@@ -47,7 +47,8 @@ SAFE_PULL_CHANGES()
 
 REPLACE_KERNEL_BINARIES()
 {
-    mkdir -p "$KERNEL_TMP_DIR"
+    local KERNEL_TMP_DIR="$KERNEL_TMP_DIR-$TARGET_PLATFORM"
+    [ ! -d "$KERNEL_TMP_DIR" ] && mkdir -p "$KERNEL_TMP_DIR"
 
     echo "Cloning/updating ExtremeKernel"
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -99,8 +99,8 @@ if $WORK; then
 fi
 
 if $KERNEL_TMP; then
-    echo "- Cleaning Kernel dir..."
-    rm -rf "$KERNEL_TMP_DIR"
+    echo "- Cleaning Kernel dir(s)..."
+    rm -rf "$KERNEL_TMP_DIR"*
 fi
 
 if $TOOLS; then


### PR DESCRIPTION
This can save some time since cleanup won't be needed to build ROM/Kernel for target with other Soc.